### PR TITLE
Geometry shader support and fix for 0.9.0 Fixes #2

### DIFF
--- a/src/ofxAutoReloadedShader.cpp
+++ b/src/ofxAutoReloadedShader.cpp
@@ -177,11 +177,7 @@ std::time_t ofxAutoReloadedShader::getLastModified( ofFile& _file )
 {
 	if( _file.exists() )
 	{
-		Poco::File& pocoFile		= _file.getPocoFile();
-		Poco::Timestamp timestamp	= pocoFile.getLastModified();
-		std::time_t fileChangedTime = timestamp.epochTime();
-		
-		return fileChangedTime;
+        return std::filesystem::last_write_time(_file.path());
 	}
 	else
 	{

--- a/src/ofxAutoReloadedShader.cpp
+++ b/src/ofxAutoReloadedShader.cpp
@@ -24,6 +24,11 @@ bool ofxAutoReloadedShader::load(string vertName, string fragName, string geomNa
 {
 	unload();
 	
+    ofShader::setGeometryOutputCount(geometryOutputCount);
+    ofShader::setGeometryInputType(geometryInputType);
+    ofShader::setGeometryOutputType(geometryOutputType);
+
+    
 	// hackety hack, clear errors or shader will fail to compile
 	GLuint err = glGetError();
 	
@@ -189,4 +194,22 @@ std::time_t ofxAutoReloadedShader::getLastModified( ofFile& _file )
 void ofxAutoReloadedShader::setMillisBetweenFileCheck( int _millis )
 {
 	millisBetweenFileCheck = _millis;
+}
+
+//--------------------------------------------------------------
+void ofxAutoReloadedShader::setGeometryInputType(GLenum type) {
+    ofShader::setGeometryInputType(type);
+    geometryInputType = type;
+}
+
+//--------------------------------------------------------------
+void ofxAutoReloadedShader::setGeometryOutputType(GLenum type) {
+    ofShader::setGeometryOutputType(type);
+    geometryOutputType = type;
+}
+
+//--------------------------------------------------------------
+void ofxAutoReloadedShader::setGeometryOutputCount(int count) {
+    ofShader::setGeometryOutputCount(count);
+    geometryOutputCount = count;
 }

--- a/src/ofxAutoReloadedShader.h
+++ b/src/ofxAutoReloadedShader.h
@@ -20,7 +20,11 @@ class ofxAutoReloadedShader : public ofShader
 		
 	void setMillisBetweenFileCheck( int _millis );
 	
-	void _update(ofEventArgs &e);	
+	void _update(ofEventArgs &e);
+    
+    void setGeometryInputType(GLenum type);
+    void setGeometryOutputType(GLenum type);
+    void setGeometryOutputCount(int count);
 	
 private:
 	
@@ -43,6 +47,9 @@ private:
 	ofFile geometryShaderFile;
 	
 	vector< std::time_t > fileChangedTimes;
+    
+    GLenum geometryInputType, geometryOutputType;
+    int geometryOutputCount;
 };
 
 


### PR DESCRIPTION
Added support for geometry shaders and rewrote method to get last write time to use boost instead of poco for 0.9.0 compatibility. 

