### PR TITLE
added bindDefaults

### DIFF
--- a/src/ofxAutoReloadedShader.cpp
+++ b/src/ofxAutoReloadedShader.cpp
@@ -75,6 +75,8 @@ bool ofxAutoReloadedShader::load(string vertName, string fragName, string geomNa
 		setupShaderFromSource(GL_GEOMETRY_SHADER_EXT, geometryShaderBuffer.getText());
 	}
 	#endif
+
+	bindDefaults();
 	
 	return linkProgram();
 }


### PR DESCRIPTION
Hi,
I could not get OpenGL3 shader attributes to work properly.
After research I've found out that ofShader::bindDefaults fix the problem.
I've added bindDefaults, so OpenGL 3 shaders can get attributes (normal, texcoord, color)
(Thanks for this awesome addon by the way)
